### PR TITLE
adding missing facilities so the math works if you try and use local*

### DIFF
--- a/rfc5424.go
+++ b/rfc5424.go
@@ -29,6 +29,10 @@ const (
 	Cron
 	Authpriv
 	Ftp
+	Ntp
+	Security
+	Console
+	Solaris-cron
 	Local0
 	Local1
 	Local2


### PR DESCRIPTION
the RFC outlines 23 facilities, this implementation only includes 19. due to the skipping of four facilities during the generation of the const, all facilities after Ftp are either missing or wrong (Local7 ends up being sent to local3, for instance)